### PR TITLE
Fix Incorrect Location for start_location when token is at start of line

### DIFF
--- a/sygus/src/base/parser.py
+++ b/sygus/src/base/parser.py
@@ -14,8 +14,14 @@ class SygusParserBase(object):
     tokens = SygusLexerBase.tokens
 
     def _get_position(self, line: int, pos: int) -> utilities.Location:
-        line_start = self.input_string.rfind('\n', 0, pos) + 1
-        end_col = (pos - line_start) + 1
+        if pos < 0:
+            line_start = self.input_string.rfind('\n', 0) + 1
+
+            end_col = line_start + 1
+        else:
+            line_start = self.input_string.rfind('\n', 0, pos) + 1
+
+            end_col = (pos - line_start) + 1
         return utilities.Location(line, end_col)
 
     def p_program(self, p):

--- a/sygus/src/v2/parser.py
+++ b/sygus/src/v2/parser.py
@@ -164,7 +164,6 @@ class SygusV2Parser(SygusParserBase):
 
     def p_grammar_def(self, p):
         """grammar_def : nonempty_arg_list TK_LPAREN grouped_rule_list_plus TK_RPAREN"""
-        print("Positions=", p.lexpos(0), p.lexpos(1), p.lexpos(2), "line=", p.lineno(0), p.lineno(1))
         start_position = self._get_position(p.lineno(1), p.lexpos(1) - 1)
         end_position = self._get_position(p.lineno(4), p.lexpos(4))
         p[0] = ast.Grammar(p[1], p[3], start_position, end_position)

--- a/sygus/src/v2/parser.py
+++ b/sygus/src/v2/parser.py
@@ -164,6 +164,7 @@ class SygusV2Parser(SygusParserBase):
 
     def p_grammar_def(self, p):
         """grammar_def : nonempty_arg_list TK_LPAREN grouped_rule_list_plus TK_RPAREN"""
+        print("Positions=", p.lexpos(0), p.lexpos(1), p.lexpos(2), "line=", p.lineno(0), p.lineno(1))
         start_position = self._get_position(p.lineno(1), p.lexpos(1) - 1)
         end_position = self._get_position(p.lineno(4), p.lexpos(4))
         p[0] = ast.Grammar(p[1], p[3], start_position, end_position)


### PR DESCRIPTION
Hi,


There is an issue with the ``Location`` when the token is at the start of the line.

**How to reproduce?**


Take any file of the <https://github.com/SyGuS-Org/benchmarks> where the grammar start at the beginning of a new line.
Parse it and run the symbol table builder.
Then checking the ``grammar.start_location`` should yield a negative column index.
Here is a snippet:
```python

use_v1: bool = False
if use_v1:
    from parsing.v1.parser import SygusV1Parser
    parser = SygusV1Parser()
else:
    from parsing.v2.parser import SygusV2Parser
    parser = SygusV2Parser()
content: str = my_file_content
program = parser.parse(content)
symbol_table = SymbolTableBuilder.run(program)
key, val = list(symbol_table.synth_functions.items())[0]
grammar: Grammar = val.synthesis_grammar
start = grammar.start_location
print(start)
```

**The Fix**

Well, we simply distinguish the case when the token is at the beginning of a line.
We check for ``pos < 0`` since in the code when the function is called we take a position and remove 1 so if we are at the start of a line pos is 0 -1 so -1.


**Why does a minor error like this matter?**

Because people can continue to build up on the SyGus specification with the available tools such as using the parser and then modifying the original files with the help of ``Location``.


